### PR TITLE
Force a relative path on the @out_path variable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,5 +10,6 @@ DaFunk::RakeTask.new do |conf|
   conf.resources = FileList["./resources/**/*"]
   conf.resources_out = conf.resources.pathmap("%{resources,out/shared}p")
   conf.mruby = "cloudwalk run"
+  conf.out_path = "out/main"
 end
 


### PR DESCRIPTION
To build the main app on windows we need to use relative paths, this
change solves the problem.

What do you think, @scalone ?
