### PR TITLE
Set new media if it was changed elsewhere.

### DIFF
--- a/lib/main.rb
+++ b/lib/main.rb
@@ -63,6 +63,7 @@ class Main < Device
   def self.thread_status_bar
     loop do
       break if ThreadScheduler.die?(:status_bar)
+      Device::Setting.set_new_media if Device::Setting.media_changed?
       DaFunk::Helper::StatusBar.check
       usleep(1000_000)
     end
@@ -92,4 +93,3 @@ class Main < Device
     "2.1.4"
   end
 end
-


### PR DESCRIPTION
A media can be changed by another application running in another process for example. In this case a thread running the status bar needs to update if that's the case.