### PR TITLE
Fixed pre_load_applications for only load ruby apps

### DIFF
--- a/lib/cloudwalk_setup.rb
+++ b/lib/cloudwalk_setup.rb
@@ -364,7 +364,7 @@ class CloudwalkSetup
   end
 
   def self.pre_load_applications
-    DaFunk::ParamsDat.executable_apps.each do |application|
+    DaFunk::ParamsDat.ruby_executable_apps.each do |application|
       application.start
     end
   end


### PR DESCRIPTION
Replaced executable_apps for ruby_executable_apps that only pre loads ruby applications.